### PR TITLE
Auto ml_prm.dll detect and NStrip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /bin
 /.vs
 /NStrip.exe
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/ManagedLibs
+/obj
+/bin
+/.vs
+/NStrip.exe

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,39 @@
+<Project>
+
+    <PropertyGroup>
+        <!-- Put your Chillout vr path in a new environnment variable CVRPATH in Windows -->
+        <OutputPath>$(CVRPATH)\Mods\</OutputPath>
+        <LangVersion>preview</LangVersion>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <TargetFramework>net472</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <!-- Required for NStrip to work -->
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <DebugType>embedded</DebugType>
+        <Optimize>true</Optimize>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Reference Include="ml_prm">
+            <HintPath>$(MsBuildThisFileDirectory)\ManagedLibs\ml_prm.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+    </ItemGroup>
+
+</Project>

--- a/GetFileAndRunNStrip.ps1
+++ b/GetFileAndRunNStrip.ps1
@@ -1,0 +1,65 @@
+$cvrPath = $env:CVRPATH
+$cvrExecutable = "ChilloutVR.exe"
+$cvrDefaultPath = "C:\Program Files (x86)\Steam\steamapps\common\ChilloutVR"
+
+if ($cvrPath -and (Test-Path "$cvrPath\$cvrExecutable")) {
+    # Found ChilloutVR.exe in the existing CVRPATH
+    Write-Host ""
+    Write-Host "Found the ChilloutVR folder on: $cvrPath"
+}
+else {
+    # Check if ChilloutVR.exe exists in default Steam location
+    if (Test-Path "$cvrDefaultPath\$cvrExecutable") {
+        # Set CVRPATH environment variable to default Steam location
+        Write-Host "Found the ChilloutVR on the default steam location, setting the CVRPATH Env Var at User Level!"
+        [Environment]::SetEnvironmentVariable("CVRPATH", $cvrDefaultPath, "User")
+        $env:CVRPATH = $cvrDefaultPath
+        $cvrPath = $env:CVRPATH
+    }
+    else {
+        Write-Host "[ERROR] ChilloutVR.exe not found in CVRPATH or the default Steam location."
+        Write-Host "        Please define the Environment Variable CVRPATH pointing to the ChilloutVR folder!"
+        return
+    }
+}
+
+$scriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+$managedLibsFolder = $scriptDir + "\ManagedLibs"
+
+if (!(Test-Path $managedLibsFolder)) {
+    New-Item -ItemType Directory -Path $managedLibsFolder
+}
+
+Write-Host "Copying ml_prm from CVR Mods folder to ManagedLibs folder..."
+Copy-Item $cvrPath\Mods\ml_prm.dll -Destination $managedLibsFolder
+
+# Create an array to hold the file names to strip
+$dllsToStrip = @('ml_prm.dll')
+
+# Check if NStrip.exe exists in the current directory
+if(Test-Path -Path ".\NStrip.exe") {
+  $nStripPath = ".\NStrip.exe"
+}
+else {
+  # Try to locate NStrip.exe in the PATH
+  $nStripPath = Get-Command -Name NStrip.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source
+  if($null -eq $nStripPath) {
+      # Display an error message if NStrip.exe could not be found
+      Write-Host "Could not find NStrip.exe in the current directory nor in the PATH." -ForegroundColor Red
+      Write-Host "Visit https://github.com/bbepis/NStrip/releases/latest to grab a copy." -ForegroundColor Red
+      return
+  }
+}
+
+# Loop through each DLL file to strip and call NStrip.exe
+foreach($dllFile in $dllsToStrip) {
+  $dllPath = Join-Path -Path $managedLibsFolder -ChildPath $dllFile
+  & $nStripPath -p -n $dllPath $dllPath
+}
+
+Write-Host ""
+Write-Host "Copied and Nstripped the ml_prm"
+Write-Host ""
+Write-Host "Press any key to exit"
+$HOST.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown") | OUT-NULL
+$HOST.UI.RawUI.Flushinputbuffer()

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # CVRLimbsGrabber
+
 Lets your limbs be grabbed in CVR.
 
 now with ragdolling. get ml_prm [here](https://github.com/SDraw/ml_mods_cvr/releases) for it to work
 
 - Limb grabbing:
 
-https://user-images.githubusercontent.com/38149279/229303321-e3d211bf-9d68-4fd2-aee7-d67dc6c34864.mp4
+<https://user-images.githubusercontent.com/38149279/229303321-e3d211bf-9d68-4fd2-aee7-d67dc6c34864.mp4>
 >
 - Avatar Pickup:
 
-https://user-images.githubusercontent.com/38149279/229303345-b08e59f1-6dcf-4a47-9c9e-b34d9f6d2470.mp4
+<https://user-images.githubusercontent.com/38149279/229303345-b08e59f1-6dcf-4a47-9c9e-b34d9f6d2470.mp4>
 >
 Requires [DesktopVRIK](https://github.com/notakidonsteam/desktopvrik) to function on desktop mode
 
-### you can make your own grabbers on avatars and props too
+## you can make your own grabbers on avatars and props too
 
 to do it get the unity package in the releases
 
@@ -21,7 +22,7 @@ included in unity package is the grabber script and a example prop
 
 to make grabber script work drag it on to the grabber and animate the grab value on and off
 
-### TODO:
+## TODO
 
 - Posing
 
@@ -29,6 +30,11 @@ to make grabber script work drag it on to the grabber and animate the grab value
 
 download project
 
-get [ml_prm](https://github.com/SDraw/ml_mods_cvr/releases), [NStrip](https://github.com/bbepis/NStrip/releases), and "RunNStrip.bat" and put them in the same folder and run "RunNstrip.bat"
+> get [ml_prm](https://github.com/SDraw/ml_mods_cvr/releases), [NStrip](https://github.com/bbepis/NStrip/releases), and "RunNStrip.bat" and put them in the same folder and run "RunNstrip.bat"
+>
+>add the new ml_prm-nstrip.dll as a reference
 
-add the new ml_prm-nstrip.dll as a reference
+or
+
+> get [NStrip](https://github.com/bbepis/NStrip/releases) and have ml_prm.dll already in your mods directory, then
+> run GetFileAndRunNStrip.ps1


### PR DESCRIPTION
## Main Aim
The aim of this merge/pull request is to, make it simpler for people to process the ml_prm.dll  
This is done by having the script, grab a copy from the CVR install mods directory and then process it and stage it in a ManagedLibs folder.  
In addition to this a Directory.Build.props file is included, to auto pickup the file from the ManagedLibs folder when project is loaded into Visual Studio, thus removing the need to manually add the reference to the dll  
  
## Additional items  
Added gitignore file to keep some dynamic files (build output) and IDE files out of the git commits  
Updated the README.md file to reference the PowerShell script as an option  