### PR TITLE
Parameter to disable grab from the grabbing player

### DIFF
--- a/CVRLimbsGrabber/GrabberComponent.cs
+++ b/CVRLimbsGrabber/GrabberComponent.cs
@@ -9,6 +9,7 @@ public class GrabberComponent : MonoBehaviour
 {
     internal PlayerAvatarMovementData MovementData;
     internal PlayerDescriptor PlayerDescriptor;
+    internal Animator PlayerAnimator;
     internal int grabber = 0;
     internal int Limb = -1;
     internal bool Grabbing;
@@ -18,10 +19,11 @@ public class GrabberComponent : MonoBehaviour
     {
         bool grabbing = false;
         if (grabber == 0) grabbing = Grab;
+        else if (!Grabbing && (PlayerAnimator?.GetBool("LimbGrabberDisableGrab") ?? false)) return; //Make sure we are not currently grabbing, or would never let go
         else if (!Friends.FriendsWith(PlayerDescriptor.ownerId) && LimbGrabber.Friend.Value) return;
         else if (grabber == 1) grabbing = (int)MovementData.AnimatorGestureLeft == 1 || MovementData.LeftMiddleCurl > 0.5;
         else if (grabber == 2) grabbing = (int)MovementData.AnimatorGestureRight == 1 || MovementData.RightMiddleCurl > 0.5;
-
+       
         if (grabbing && !Grabbing)
         {
             LimbGrabber.Grab(this);

--- a/CVRLimbsGrabber/Patches.cs
+++ b/CVRLimbsGrabber/Patches.cs
@@ -19,12 +19,14 @@ public class Patches
         LeftGrabber.MovementData = ____playerAvatarMovementDataCurrent;
         LeftGrabber.PlayerDescriptor = ____playerDescriptor;
         LeftGrabber.grabber = 1;
+        LeftGrabber.PlayerAnimator = ____animator;
 
         Transform RightHand = ____animator.GetBoneTransform(HumanBodyBones.RightHand);
         GrabberComponent RightGrabber = RightHand.gameObject.AddComponent<GrabberComponent>();
         RightGrabber.MovementData = ____playerAvatarMovementDataCurrent;
         RightGrabber.PlayerDescriptor = ____playerDescriptor;
         RightGrabber.grabber = 2;
+        RightGrabber.PlayerAnimator = ____animator;
     }
 
     [HarmonyPostfix]


### PR DESCRIPTION
This adds an optional parameter that goes on the _grabbing_ player's avatar. 
If "LimbGrabberDisableGrab" is set to true then they will not be able to grab anything.

The use case I see for this is when interacting with other players with the mod, it can sometimes be annoying with how easy it is to grab them. With this option, you can just set the parameter true on your own animator and now you can not grab others. 